### PR TITLE
feat: new filter system

### DIFF
--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -1,0 +1,24 @@
+import	React, {ReactElement, ReactNode}	from	'react';
+
+type		TFilters = {
+	availableCategories: string[],
+	currentCategory: string,
+	onSelect: (s: string) => void
+}
+function	Filters({availableCategories, currentCategory, onSelect}: TFilters): ReactElement {
+	return (
+		<div aria-label={'filters'} className={'flex flex-row justify-center items-center mb-7 -ml-1 space-x-2 md:ml-0'}>
+			{availableCategories.map((category: string): ReactNode => (
+				<button
+					key={category}
+					aria-selected={category === currentCategory}
+					onClick={(): void => onSelect(category)}
+					className={'flex justify-center items-center px-2 h-8 border transition-colors cursor-pointer rounded-default macarena--filter'}>
+					<p className={'text-xs md:text-base'}>{category}</p>
+				</button>
+			))}
+		</div>
+	);
+}
+
+export default Filters;

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -14,7 +14,7 @@ type	TYearnContext = {
 const	YearnContext = createContext<TYearnContext>({
 	vaults: [],
 	nonce: 0,
-	defaultCategories: ['simple_saver', 'usd_stable', 'blue_chip']
+	defaultCategories: ['Simple Saver', 'USD Stable', 'Blue Chip']
 });
 export const YearnContextApp = ({children}: {children: ReactElement}): ReactElement => {
 	const	{chainID} = useWeb3();

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -8,14 +8,20 @@ import type {TToken, TVault, TVaultAPI}						from	'contexts/useYearn.d';
 
 type	TYearnContext = {
 	vaults: TVault[],
-	nonce: number
+	nonce: number,
+	defaultCategories: string[]
 }
-const	YearnContext = createContext<TYearnContext>({vaults: [], nonce: 0});
+const	YearnContext = createContext<TYearnContext>({
+	vaults: [],
+	nonce: 0,
+	defaultCategories: ['simple_saver', 'usd_stable', 'blue_chip']
+});
 export const YearnContextApp = ({children}: {children: ReactElement}): ReactElement => {
 	const	{chainID} = useWeb3();
 	const	{networks} = useSettings();
 	const	[vaults, set_vaults] = React.useState<TVault[]>([]);
 	const	[nonce, set_nonce] = React.useState(0);
+	const	[defaultCategories, set_defaultCategories] = React.useState<string[]>([]);
 
 	const getYearnVaults = React.useCallback(async (): Promise<void> => {
 		NProgress.start();
@@ -159,36 +165,36 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 			if (vault.token.symbol === 'cDAI+cUSDC+USDT')
 				vault.token.symbol = 'cUSDT';
 
-			vault.categories = ['simple_saver'];
+			vault.categories = ['Simple Saver'];
 			vault.chainID = chainID;
 			if (chainID === 1 || chainID === 1337) {
 				if (toAddress(vault.address) === toAddress('0xdA816459F1AB5631232FE5e97a05BBBb94970c95')) //DAI
-					vault.categories = ['simple_saver', 'usd_stable'];
+					vault.categories = ['Simple Saver', 'USD Stable'];
 				if (toAddress(vault.address) === toAddress('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')) //usdc
-					vault.categories = ['simple_saver', 'usd_stable'];
+					vault.categories = ['Simple Saver', 'USD Stable'];
 				if (toAddress(vault.address) === toAddress('0x7Da96a3891Add058AdA2E826306D812C638D87a7')) //usdt
-					vault.categories = ['simple_saver', 'usd_stable'];
+					vault.categories = ['Simple Saver', 'USD Stable'];
 				if (toAddress(vault.address) === toAddress('0xdb25cA703181E7484a155DD612b06f57E12Be5F0')) //YFI
-					vault.categories = ['simple_saver', 'blue_chip'];
+					vault.categories = ['Simple Saver', 'Blue Chip'];
 				if (toAddress(vault.address) === toAddress('0xa258C4606Ca8206D8aA700cE2143D7db854D168c')) //ETH
-					vault.categories = ['simple_saver', 'blue_chip'];
+					vault.categories = ['Simple Saver', 'Blue Chip'];
 				if (toAddress(vault.address) === toAddress('0xA696a63cc78DfFa1a63E9E50587C197387FF6C7E')) //BTC
-					vault.categories = ['simple_saver', 'blue_chip'];
+					vault.categories = ['Simple Saver', 'Blue Chip'];
 			} else if (chainID === 250) {
 				if (toAddress(vault.address) === toAddress('0x0DEC85e74A92c52b7F708c4B10207D9560CEFaf0')) //yvWFTM
-					vault.categories = ['simple_saver', 'blue_chip'];
+					vault.categories = ['Simple Saver', 'Blue Chip'];
 				if (toAddress(vault.address) === toAddress('0xEF0210eB96c7EB36AF8ed1c20306462764935607')) //yvUSDC
-					vault.categories = ['simple_saver', 'usd_stable'];
+					vault.categories = ['Simple Saver', 'USD Stable'];
 				if (toAddress(vault.address) === toAddress('0x637eC617c86D24E421328e6CAEa1d92114892439')) //yvDAI
-					vault.categories = ['simple_saver', 'usd_stable'];
+					vault.categories = ['Simple Saver', 'USD Stable'];
 				if (toAddress(vault.address) === toAddress('0x148c05caf1Bb09B5670f00D511718f733C54bC4c')) //yvUSDT
-					vault.categories = ['simple_saver', 'usd_stable'];
+					vault.categories = ['Simple Saver', 'USD Stable'];
 				if (toAddress(vault.address) === toAddress('0xCe2Fc0bDc18BD6a4d9A725791A3DEe33F3a23BB7')) //yvWETH
-					vault.categories = ['simple_saver', 'blue_chip'];
+					vault.categories = ['Simple Saver', 'Blue Chip'];
 				if (toAddress(vault.address) === toAddress('0xd817A100AB8A29fE3DBd925c2EB489D67F758DA9')) //yvWBTC
-					vault.categories = ['simple_saver', 'blue_chip'];
+					vault.categories = ['Simple Saver', 'Blue Chip'];
 				if (toAddress(vault.address) === toAddress('0x2C850cceD00ce2b14AA9D658b7Cad5dF659493Db')) //yvYFI
-					vault.categories = ['simple_saver', 'blue_chip'];
+					vault.categories = ['Simple Saver', 'Blue Chip'];
 			}
 			_vaults.push(vault);
 		}
@@ -196,6 +202,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 		performBatchedUpdates((): void => {
 			set_vaults(_vaults);
 			set_nonce((n): number => n + 1);
+			set_defaultCategories([...new Set(_vaults.map((vault): string[] => vault.categories).flat())]);
 			NProgress.done();
 		});
 	}, [chainID, networks]);
@@ -205,7 +212,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 	}, [getYearnVaults]);
 
 	return (
-		<YearnContext.Provider value={{vaults, nonce}}>
+		<YearnContext.Provider value={{vaults, nonce, defaultCategories}}>
 			<WalletContextApp vaults={vaults}>
 				{children}
 			</WalletContextApp>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -95,7 +95,7 @@ function	Vaults({vaults}: {vaults: TVault[]}): ReactElement {
 function	Index(): ReactElement {
 	const	{vaults, nonce: dataNonce, defaultCategories} = useYearn();
 	const	[filteredVaults, set_filteredVaults] = React.useState<TVault[]>([]);
-	const	[selectedCategory, set_selectedCategory] = React.useState('simple_saver');
+	const	[selectedCategory, set_selectedCategory] = React.useState('');
 
 	/* 🔵 - Yearn Finance ******************************************************
 	** This effect is triggered every time the vault list or the search term is
@@ -104,7 +104,8 @@ function	Index(): ReactElement {
 	**************************************************************************/
 	React.useEffect((): void => {
 		let		_filteredVaults = [...vaults];
-		_filteredVaults = _filteredVaults.filter((vault): boolean => vault.categories.includes(selectedCategory));
+		if (selectedCategory !== '')
+			_filteredVaults = _filteredVaults.filter((vault): boolean => vault.categories.includes(selectedCategory));
 		_filteredVaults = _filteredVaults.sort((a, b): number => b.apy.net_apy - a.apy.net_apy);
 		utils.performBatchedUpdates((): void => {
 			set_filteredVaults(_filteredVaults);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,12 @@
-import	React, {ReactElement}			from	'react';
-import	Image							from	'next/image';
-import	Link							from	'next/link';
-import	{motion}						from	'framer-motion';
-import	{Button, Card}					from	'@yearn-finance/web-lib/components';
-import	* as utils						from	'@yearn-finance/web-lib/utils';
-import	useYearn						from	'contexts/useYearn';
-import type {TVault}					from	'contexts/useYearn.d';
+import	React, {ReactElement}	from	'react';
+import	Image					from	'next/image';
+import	Link					from	'next/link';
+import	{motion}				from	'framer-motion';
+import	{Button, Card}			from	'@yearn-finance/web-lib/components';
+import	* as utils				from	'@yearn-finance/web-lib/utils';
+import	useYearn				from	'contexts/useYearn';
+import type {TVault}			from	'contexts/useYearn.d';
+import	Filters					from	'components/Filters';
 
 function	VaultCard({currentVault}: {currentVault: TVault}): ReactElement {
 	const slashMotion = {
@@ -92,10 +93,9 @@ function	Vaults({vaults}: {vaults: TVault[]}): ReactElement {
 }
 
 function	Index(): ReactElement {
-	const	defaultSelectedCategories = {usdStable: false, blueChip: false, simpleSavers: false};
-	const	{vaults, nonce: dataNonce} = useYearn();
+	const	{vaults, nonce: dataNonce, defaultCategories} = useYearn();
 	const	[filteredVaults, set_filteredVaults] = React.useState<TVault[]>([]);
-	const	[selectedCategories, set_selectedCategories] = React.useState({...defaultSelectedCategories, simpleSavers: true});
+	const	[selectedCategory, set_selectedCategory] = React.useState('simple_saver');
 
 	/* 🔵 - Yearn Finance ******************************************************
 	** This effect is triggered every time the vault list or the search term is
@@ -104,42 +104,22 @@ function	Index(): ReactElement {
 	**************************************************************************/
 	React.useEffect((): void => {
 		let		_filteredVaults = [...vaults];
-		_filteredVaults = _filteredVaults.filter((vault): boolean => (
-			(selectedCategories.simpleSavers && vault.categories.includes('simple_saver'))
-			|| (selectedCategories.usdStable && vault.categories.includes('usd_stable'))
-			|| (selectedCategories.blueChip && vault.categories.includes('blue_chip'))
-		));
+		_filteredVaults = _filteredVaults.filter((vault): boolean => vault.categories.includes(selectedCategory));
 		_filteredVaults = _filteredVaults.sort((a, b): number => b.apy.net_apy - a.apy.net_apy);
 		utils.performBatchedUpdates((): void => {
 			set_filteredVaults(_filteredVaults);
 		});
-	}, [dataNonce, vaults, selectedCategories]);
+	}, [dataNonce, vaults, selectedCategory]);
 
 	/* 🔵 - Yearn Finance ******************************************************
 	** Main render of the page.
 	**************************************************************************/
 	return (
 		<div className={'z-0 pb-10 w-full md:pb-20'}>
-			<div aria-label={'filters'} className={'flex flex-row justify-center items-center mb-7 -ml-1 space-x-2 md:ml-0'}>
-				<button
-					aria-selected={selectedCategories.simpleSavers}
-					onClick={(): void => set_selectedCategories({...defaultSelectedCategories, simpleSavers: true})}
-					className={'flex justify-center items-center px-2 h-8 border transition-colors cursor-pointer rounded-default macarena--filter'}>
-					<p className={'text-xs md:text-base'}>{'Simple Savers'}</p>
-				</button>
-				<button
-					aria-selected={selectedCategories.usdStable}
-					onClick={(): void => set_selectedCategories({...defaultSelectedCategories, usdStable: true})}
-					className={'flex justify-center items-center px-2 h-8 border transition-colors cursor-pointer rounded-default macarena--filter'}>
-					<p className={'text-xs md:text-base'}>{'USD Stables'}</p>
-				</button>
-				<button
-					aria-selected={selectedCategories.blueChip}
-					onClick={(): void => set_selectedCategories({...defaultSelectedCategories, blueChip: true})}
-					className={'flex justify-center items-center px-2 h-8 border transition-colors cursor-pointer rounded-default macarena--filter'}>
-					<p className={'text-xs md:text-base'}>{'Blue Chips'}</p>
-				</button>
-			</div>
+			<Filters
+				currentCategory={selectedCategory}
+				availableCategories={defaultCategories}
+				onSelect={(category: string): void => set_selectedCategory(category)} />
 
 			<Vaults vaults={filteredVaults} />
 		</div>


### PR DESCRIPTION
After some talk with @MarcoWorms, the filter system is not great and may be difficult to update. This PR try to solve this by abstracting the filter logic based on the filters added by the user.

- `defaultCategories` are set on the `useYearn` context
- `defaultCategories` is updated after the vault filtering setup to match all the available categories
- Category name is category filter
- Reduce `selectedCategories` object complexity