### PR TITLE
fix: Overflow in the deposit / withdraw widget

### DIFF
--- a/components/vault/DepositCard.tsx
+++ b/components/vault/DepositCard.tsx
@@ -313,7 +313,7 @@ function DepositCard({currentVault}: {currentVault: TVault}): ReactElement{
 								<b>{currentVault?.token?.symbol || ''}</b>
 							</div>
 						</div>
-						<div className={'rounded-default flex h-24 w-full flex-col bg-neutral-200 py-2 px-4 md:h-32 md:py-4 md:px-6'}>
+						<div className={'rounded-default flex h-24 w-full flex-col overflow-hidden bg-neutral-200 py-2 px-4 md:h-32 md:py-4 md:px-6'}>
 							<Input.BigNumber
 								balance={utils.format.toNormalizedAmount(balanceOfToken, currentVault?.decimals)}
 								price={utils.format.toNormalizedValue(priceOfToken, 6)}


### PR DESCRIPTION
Fix the overflow issue with the deposit / withdraw widget

<img width="493" alt="Screenshot 2023-04-26 at 15 26 39" src="https://user-images.githubusercontent.com/78794805/234574161-aa7239ff-d843-47c1-ab6a-c7f9f7ba83b4.png">

The dollar amount still wraps to a new line, that will need to be changed in the web -lib