### PR TITLE
refactor: Trim large numbers with ellipsis

### DIFF
--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -102,7 +102,7 @@ function	InputBigNumber(props: TInputBigNumber): ReactElement {
 				}}
 				isWithMax={isWithMax}
 				disabled={props.disabled} />
-			<p>{`$ ${formatAmount(safeValue * price, 2, 2)}`}</p>
+			<p>{`$ ${formatAmount(safeValue * price, 2, 2, 18)}`}</p>
 		</label>
 	);
 }

--- a/components/vault/DepositCard.tsx
+++ b/components/vault/DepositCard.tsx
@@ -285,7 +285,7 @@ function DepositCard({currentVault}: {currentVault: TVault}): ReactElement{
 										</div>
 										<div className={'flex justify-end'}>
 											<p className={'text-typo-secondary bg-neutral-0 z-10 pl-2 text-right'}>
-												{formatAmount(getWithdrawReceiveTokens(), 2, 6)}
+												{formatAmount(getWithdrawReceiveTokens(), 2, 6, 24)}
 											</p>
 										</div>
 									</dd>
@@ -299,7 +299,7 @@ function DepositCard({currentVault}: {currentVault: TVault}): ReactElement{
 										</div>
 										<div className={'flex justify-end'}>
 											<p className={'text-typo-secondary bg-neutral-0 z-10 pl-2 text-right'}>
-												{`$ ${formatAmount(getWithdrawReceiveValue(), 2, 2)}`}
+												{`$ ${formatAmount(getWithdrawReceiveValue(), 2, 2, 24)}`}
 											</p>
 										</div>
 									</dd>
@@ -345,7 +345,7 @@ function DepositCard({currentVault}: {currentVault: TVault}): ReactElement{
 									</div>
 									<div className={'flex justify-end'}>
 										<p className={'text-typo-secondary bg-neutral-0 z-10 pl-2 text-right'}>
-											{formatAmount(getDepositReceiveTokens(), 2, 6)}
+											{formatAmount(getDepositReceiveTokens(), 2, 6, 24)}
 										</p>
 									</div>
 								</dd>
@@ -359,7 +359,7 @@ function DepositCard({currentVault}: {currentVault: TVault}): ReactElement{
 									</div>
 									<div className={'flex justify-end'}>
 										<p className={'text-typo-secondary bg-neutral-0 z-10 pl-2 text-right'}>
-											{`$ ${formatAmount(getDepositReceiveValue(), 2, 2)}`}
+											{`$ ${formatAmount(getDepositReceiveValue(), 2, 2, 24)}`}
 										</p>
 									</div>
 								</dd>


### PR DESCRIPTION
Improve how big numbers are displayed

## Before

<img width="497" alt="Screenshot 2023-05-02 at 9 25 42" src="https://user-images.githubusercontent.com/78794805/235594112-ca328a80-0f4e-4d4d-8a6e-6409b0bc9cd5.png">

## After

<img width="491" alt="Screenshot_2_5_2023__9_24" src="https://user-images.githubusercontent.com/78794805/235594035-104e9f5a-927a-4a12-bef2-2bacdc6ead57.png">
