### PR TITLE
fix: Vault in another network

### DIFF
--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -32,7 +32,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 	const getYearnVaults = React.useCallback(async (): Promise<void> => {
 		NProgress.start();
 		
-		const parsedChainID = chainID ? Number(chainID) === 1337 ? 1 : Number(chainID) || 1 : web3.chainID;
+		const parsedChainID = chainID ? Number(chainID) === 1337 ? 1 : Number(chainID) : web3.chainID || 1;
 
 		const	networkData = networks[parsedChainID];
 		const	[api, meta, tok, vs] = await Promise.allSettled([

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -32,7 +32,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 	const getYearnVaults = React.useCallback(async (): Promise<void> => {
 		NProgress.start();
 		
-		const parsedChainID = chainID ? Number(chainID) === 1337 ? 1 : Number(chainID) : web3.chainID || 1;
+		const parsedChainID = (chainID ? (Number(chainID) === 1337 ? 1 : Number(chainID)) : web3.chainID) || 1;
 
 		const	networkData = networks[parsedChainID];
 		const	[api, meta, tok, vs] = await Promise.allSettled([

--- a/pages/[chainID]/vault/[address].tsx
+++ b/pages/[chainID]/vault/[address].tsx
@@ -20,7 +20,7 @@ import type {TVault}						from	'contexts/useYearn.d';
 function	Vault(): ReactElement {
 	const	router = useRouter();
 	const	{vaults} = useYearn();
-	const	{chainID} = useWeb3();
+	const	{chainID, isActive} = useWeb3();
 	const 	{safeChainID} = useChainID();
 	const	[currentVault, set_currentVault] = React.useState<TVault | undefined>(vaults.find((vault): boolean => toAddress(vault.address) === router.query.address));
 	const {toast, toastMaster} = yToast();
@@ -36,7 +36,7 @@ function	Vault(): ReactElement {
 			return;
 		}
 
-		if (!!safeChainID && currentVault && Number(currentVault?.chainID) !== safeChainID) {
+		if (isActive && !!safeChainID && currentVault && Number(currentVault?.chainID) !== safeChainID) {
 			const vaultChainName = CHAINS[currentVault.chainID]?.name;
 			const chainName = CHAINS[safeChainID]?.name;
 
@@ -48,7 +48,7 @@ function	Vault(): ReactElement {
 
 			set_toastState({id: toastId, isOpen: true});
 		}
-	}, [currentVault, safeChainID, toast, toastMaster, toastState.id, toastState.isOpen]);
+	}, [currentVault, isActive, safeChainID, toast, toastMaster, toastState.id, toastState.isOpen]);
 
 	React.useEffect((): void => {
 		if (router.query.address) {

--- a/pages/[chainID]/vault/[address].tsx
+++ b/pages/[chainID]/vault/[address].tsx
@@ -62,7 +62,6 @@ function	Vault(): ReactElement {
 	**************************************************************************/
 	return (
 		<div className={'z-0 w-full'}>
-			{/* <div>{'xrsatrst'}</div> */}
 			<Link href={'/'}>
 				<div className={'mb-4 flex cursor-pointer flex-row items-center  space-x-2 opacity-40 transition-opacity duration-300 hover:opacity-100'}>
 					<Chevron className={'h-4 w-4'} />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import	{useRouter}													from	'next/router';
 import	{AnimatePresence, motion}									from	'framer-motion';
 import	{KBarProvider, Action, createAction, useRegisterActions}	from	'kbar';
 import {useWeb3} 													from 	'@yearn-finance/web-lib/contexts/useWeb3';
+import {useChainID} 												from	'@yearn-finance/web-lib/hooks/useChainID';
 import NetworkEthereum 												from 	'@yearn-finance/web-lib/icons/IconNetworkEthereum';
 import NetworkFantom 												from 	'@yearn-finance/web-lib/icons/IconNetworkFantom';
 import SocialGithub 												from 	'@yearn-finance/web-lib/icons/IconSocialGithub';
@@ -140,6 +141,7 @@ function	KBarWrapper(): React.ReactElement {
 	const	[actions, set_actions] = React.useState<Action[]>([]);
 	const	{vaults} = useYearn();
 	const	router = useRouter();
+	const	{safeChainID} = useChainID();
 
 	React.useEffect((): void => {
 		const	_actions = [];
@@ -148,7 +150,7 @@ function	KBarWrapper(): React.ReactElement {
 				name: vault.display_name || vault.name,
 				keywords: `${vault.display_name || vault.name} ${vault.symbol} ${vault.address}`,
 				section: 'Vaults',
-				perform: async (): Promise<boolean> => router.push(`/vault/${vault.address}`),
+				perform: async (): Promise<boolean> => router.push(`/${safeChainID}/vault/${vault.address}`),
 				icon: <Image src={vault.token.icon} alt={vault.display_name || vault.name} width={36} height={36} />,
 				subtitle: `${vault.address} - ${vault.token.symbol}`
 			}));

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,13 +5,16 @@ import	{motion}				from	'framer-motion';
 import	useYearn				from	'contexts/useYearn';
 import	Filters					from	'components/Filters';
 import {Card} 					from 	'components/common/Card';
-import {formatAmount} 			from 	'@yearn-finance/web-lib/utils/format.number';
+import {useChainID}				from	'@yearn-finance/web-lib/hooks/useChainID';
 import {Button} 				from 	'@yearn-finance/web-lib/components/Button';
+import {formatAmount} 			from 	'@yearn-finance/web-lib/utils/format.number';
 import performBatchedUpdates 	from 	'@yearn-finance/web-lib/utils/performBatchedUpdates';
 
 import type {TVault}			from	'contexts/useYearn.d';
 
 function	VaultCard({currentVault}: {currentVault: TVault}): ReactElement {
+	const	{safeChainID} = useChainID();
+	
 	const slashMotion = {
 		rest: {x: -8, y: -8},
 		hover: {x: -4, y: -4}
@@ -19,7 +22,7 @@ function	VaultCard({currentVault}: {currentVault: TVault}): ReactElement {
 
 	return (
 		<div className={'w-full'}>
-			<Link href={`/vault/${currentVault.address}`} passHref>
+			<Link href={`/${safeChainID}/vault/${currentVault.address}`} passHref>
 				<a>
 					<Card className={'yearn--card col-span-1 md:col-span-3'} padding={'none'}>
 						<motion.div initial={'rest'} whileHover={'hover'} animate={'rest'} className={'cursor-pointer'}>


### PR DESCRIPTION
Show vaults in a different network to the one the user is connected to.

* Change the path to the vault from `/vault/${vault.address}` to `/${safeChainID}/vault/${vault.address}`, so that we know the network of the vault;
* Display toast with warning message;

<img width="1582" alt="Screenshot 2023-05-04 at 14 31 23" src="https://user-images.githubusercontent.com/78794805/236194632-0450849b-3a1c-41bc-9307-57e017d92c47.png">
